### PR TITLE
Fix sensor_resistor for FYSETC cheetah 3.0

### DIFF
--- a/0.2/Firmware&OS/printer.cfg
+++ b/0.2/Firmware&OS/printer.cfg
@@ -1,4 +1,4 @@
-# This file contains common pin mappings for the Fysetc Cheetah v2.0
+# This file contains common pin mappings for the Fysetc Cheetah v3.0
 # board. To use this config, the firmware should be compiled for the
 # STM32F446 with "No bootloader" and Communication interface USB
 
@@ -74,7 +74,7 @@ uart_pin: PB3
 uart_address: 0
 interpolate: False
 run_current: 0.7
-sense_resistor: 0.110
+sense_resistor: 0.220
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 diag_pin: ^PA2                                                      # YOU NEED TO JUMP THIS DIAG PIN ON YOUR BOARD FOR SENSORLESS HOMING TO WORK 
 driver_SGTHRS: 100                                                  # this is set to 255 which is the MAX sensitivity for sensorless homing, you will need to tune this later
@@ -101,7 +101,7 @@ uart_pin: PB3
 uart_address: 1
 interpolate: False
 run_current: 0.7
-sense_resistor: 0.110
+sense_resistor: 0.220
 stealthchop_threshold: 0                                            # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 diag_pin: ^PA3                                                      # YOU NEED TO JUMP THIS DIAG PIN ON YOUR BOARD FOR SENSORLESS HOMING TO WORK 
 driver_SGTHRS: 100                                                  # this is set to 255 which is the MAX sensitivity for sensorless homing, you will need to tune this later
@@ -132,8 +132,7 @@ uart_address: 2
 interpolate: False
 # For FYSETC 42HSC1404B-200N8
 run_current: 0.3
-
-sense_resistor: 0.110
+sense_resistor: 0.220
 stealthchop_threshold: 0                                             # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 
 #####################################################################
@@ -173,7 +172,7 @@ uart_pin: PB3
 uart_address: 3
 interpolate: False
 run_current: 0.7
-sense_resistor: 0.110
+sense_resistor: 0.220
 stealthchop_threshold: 0                                            # Set to 0 for spreadcycle, avoid using stealthchop on extruder
 
 #####################################################################


### PR DESCRIPTION
Correct the sensor resistor settings for cheetah 3.0.   The 2.0 and 3.0 both have dual 220Rs, the  cheetah 1.2 and the 2209 standalone drivers had the 110Rs.

@GerogeFu submitted the cheetah 3.0 to Voron's v0 github recently with the correct values.  https://github.com/VoronDesign/Voron-0/pull/324/commits/c60e18767d7f378fdfdc9439707bd4af4f4c70fd